### PR TITLE
Add support for jsFutures and spawn_local

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ keep_worker_alive = []
 
 [dependencies]
 wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4.42"
 web-sys = { version = "0.3", features = [
     "Blob",
     "DedicatedWorkerGlobalScope",
@@ -33,6 +34,8 @@ web-sys = { version = "0.3", features = [
 ] }
 js-sys = "0.3"
 futures = "0.3"
+async-std = "1.12.0"
+once_cell = "1.8"
 
 [dev-dependencies]
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [features]
 default = ["es_modules"]
 es_modules = []
+keep_worker_alive = []
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/src/wasm32/js/web_worker.js
+++ b/src/wasm32/js/web_worker.js
@@ -20,16 +20,6 @@ self.onmessage = event => {
         // Enter rust code by calling entry point defined in `lib.rs`.
         // This executes closure defined by work context.
         wasm.wasm_thread_entry_point(work);
-
-       // Once done, check if worker should close based on the "keep_worker_alive" feature
-       if(!wasm.keep_worker_alive()){
-            // Periodically check if the thread can close
-            setInterval(()=>{
-                if(wasm.check_can_close(thread_key)){
-                    close();
-                }
-            }, 200);
-        }
     });
 };
   

--- a/src/wasm32/js/web_worker.js
+++ b/src/wasm32/js/web_worker.js
@@ -20,7 +20,6 @@ self.onmessage = event => {
         // Enter rust code by calling entry point defined in `lib.rs`.
         // This executes closure defined by work context.
         wasm.wasm_thread_entry_point(work);
-        close();
 
        // Once done, check if worker should close based on the "keep_worker_alive" feature
        if(!wasm.keep_worker_alive()){

--- a/src/wasm32/js/web_worker.js
+++ b/src/wasm32/js/web_worker.js
@@ -21,8 +21,11 @@ self.onmessage = event => {
         // This executes closure defined by work context.
         wasm.wasm_thread_entry_point(work);
 
-        // Once done, terminate web worker
+       // Once done, check if worker should close
+       if(!wasm.keep_worker_alive()){
+        // terminate web worker
         close();
+    }
     });
 };
   

--- a/src/wasm32/js/web_worker_module.js
+++ b/src/wasm32/js/web_worker_module.js
@@ -1,5 +1,5 @@
 // synchronously, using the browser, import wasm_bindgen shim JS scripts
-import init, {wasm_thread_entry_point, keep_worker_alive, check_can_close} from "WASM_BINDGEN_SHIM_URL";
+import init, {wasm_thread_entry_point} from "WASM_BINDGEN_SHIM_URL";
 
 // Wait for the main thread to send us the shared module/memory and work context.
 // Once we've got it, initialize it all with the `wasm_bindgen` global we imported via
@@ -20,15 +20,5 @@ self.onmessage = event => {
         // Enter rust code by calling entry point defined in `lib.rs`.
         // This executes closure defined by work context.
         wasm_thread_entry_point(work);
-
-        // Once done, check if worker should close based on the "keep_worker_alive" feature
-        if(!keep_worker_alive()){
-            // Periodically check if the thread can close
-            setInterval(()=>{
-                if(check_can_close(thread_key)){
-                    close();
-                }
-            }, 200);
-        }
     });
 };

--- a/src/wasm32/js/web_worker_module.js
+++ b/src/wasm32/js/web_worker_module.js
@@ -1,5 +1,5 @@
 // synchronously, using the browser, import wasm_bindgen shim JS scripts
-import init, {wasm_thread_entry_point} from "WASM_BINDGEN_SHIM_URL";
+import init, {wasm_thread_entry_point, keep_worker_alive} from "WASM_BINDGEN_SHIM_URL";
 
 // Wait for the main thread to send us the shared module/memory and work context.
 // Once we've got it, initialize it all with the `wasm_bindgen` global we imported via
@@ -21,7 +21,10 @@ self.onmessage = event => {
         // This executes closure defined by work context.
         wasm_thread_entry_point(work);
 
-        // Once done, terminate web worker
-        close();
+        // Once done, check if worker should close
+        if(!keep_worker_alive()){
+            // terminate web worker
+            close();
+        }
     });
 };

--- a/src/wasm32/mod.rs
+++ b/src/wasm32/mod.rs
@@ -33,6 +33,14 @@ pub fn wasm_thread_entry_point(ptr: u32) {
     WorkerMessage::ThreadComplete.post();
 }
 
+#[wasm_bindgen]
+pub fn keep_worker_alive() -> bool {
+    #[cfg(feature = "keep_worker_alive")]
+    return true;
+    #[cfg(not(feature = "keep_worker_alive"))]
+    return false;
+}
+
 /// Used to relay spawn requests from web workers to main thread
 struct BuilderRequest {
     builder: Builder,

--- a/src/wasm32/scoped.rs
+++ b/src/wasm32/scoped.rs
@@ -9,6 +9,7 @@ use std::{
 
 use super::{signal::Signal, utils::is_web_worker_thread, Builder, JoinInner};
 
+
 /// A scope to spawn scoped threads in.
 ///
 /// See [`scope`] for details.
@@ -171,8 +172,11 @@ impl Builder {
         F: FnOnce() -> T + Send + 'scope,
         T: Send + 'scope,
     {
+        let thread_key = crate::wasm32::utils::create_available_thread_key();
+        let mut map = crate::wasm32::CAN_CLOSE_MAP.lock().unwrap();
+        map.insert(thread_key, true);
         Ok(ScopedJoinHandle(unsafe {
-            self.spawn_unchecked_(f, Some(scope.data.clone()))
+            self.spawn_unchecked_(f, Some(scope.data.clone()), thread_key)
         }?))
     }
 }

--- a/src/wasm32/scoped.rs
+++ b/src/wasm32/scoped.rs
@@ -172,11 +172,8 @@ impl Builder {
         F: FnOnce() -> T + Send + 'scope,
         T: Send + 'scope,
     {
-        let thread_key = crate::wasm32::utils::create_available_thread_key();
-        let mut map = crate::wasm32::CAN_CLOSE_MAP.lock().unwrap();
-        map.insert(thread_key, true);
         Ok(ScopedJoinHandle(unsafe {
-            self.spawn_unchecked_(f, Some(scope.data.clone()), thread_key)
+            self.spawn_unchecked_(f, Some(scope.data.clone()))
         }?))
     }
 }

--- a/src/wasm32/utils.rs
+++ b/src/wasm32/utils.rs
@@ -6,7 +6,6 @@ use std::{
 
 use wasm_bindgen::prelude::*;
 use web_sys::{Blob, Url, WorkerGlobalScope};
-use crate::wasm32::CAN_CLOSE_MAP;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     if let Some(window) = web_sys::window() {
@@ -105,18 +104,3 @@ impl<T> SpinLockMutex for Mutex<T> {
     }
 }
 
-pub fn create_available_thread_key() -> u32 {
-    let mut thread_key: Option<u32> = None;
-
-    let mut map = CAN_CLOSE_MAP.lock().unwrap();
-
-    for key in 0..=std::u32::MAX {
-        if !map.contains_key(&key) {
-            map.insert(key, false);
-            thread_key = Some(key);
-            break;
-        }
-    }
-
-    thread_key.expect("Unable to generate unique thread key")
-}

--- a/src/wasm32/utils.rs
+++ b/src/wasm32/utils.rs
@@ -6,6 +6,7 @@ use std::{
 
 use wasm_bindgen::prelude::*;
 use web_sys::{Blob, Url, WorkerGlobalScope};
+use crate::wasm32::CAN_CLOSE_MAP;
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     if let Some(window) = web_sys::window() {
@@ -102,4 +103,20 @@ impl<T> SpinLockMutex for Mutex<T> {
             }
         }
     }
+}
+
+pub fn create_available_thread_key() -> u32 {
+    let mut thread_key: Option<u32> = None;
+
+    let mut map = CAN_CLOSE_MAP.lock().unwrap();
+
+    for key in 0..=std::u32::MAX {
+        if !map.contains_key(&key) {
+            map.insert(key, false);
+            thread_key = Some(key);
+            break;
+        }
+    }
+
+    thread_key.expect("Unable to generate unique thread key")
 }


### PR DESCRIPTION
The current method of executing a future is by blocking the thread with `futures::executor::block_on`. However, this also blocks the JavaScript event loop, so JavaScript promises will never resolve and awaiting a jsFuture will permanently freeze the thread. In order to await a jsFuture, `wasm_bindgen_futures::spawn_local` must be used. However, this returns immediately, which currently causes the thread to close before the promise can resolve.

One basic solution is is a simple feature flag `keep_worker_alive`, which simply prevents the thread from closing. This is implemented in the first commit. Since the thread never closes, `spawn_local` has enough time to complete any asynchronous code, but keeping threads permanently open is not ideal.

My second commit solves this problem by using a static hashmap to keep track of whether each thread should be open or closed. This hashmap is periodically checked by each thread after running the function. If this value is true, the thread closes and the key-value pair is removed. Since the `spawn` function initializes the value to true, it will close immediately after running the function, which is how the current implementation works. In the `spawn_async`, function, the value is initialized to false and will only be set to true once the future is complete. This allows the thread to remain open until the js promise has resolved.

I provide tests for both solutions, and there seems to be no backwards compatibility issues.