### PR TITLE
Feature flag to keep thread alive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [features]
 default = ["es_modules"]
 es_modules = []
+keep_worker_alive = []
 
 [dependencies]
 wasm-bindgen = "0.2"

--- a/src/wasm32/js/web_worker.js
+++ b/src/wasm32/js/web_worker.js
@@ -5,7 +5,7 @@ importScripts('WASM_BINDGEN_SHIM_URL');
 // Once we've got it, initialize it all with the `wasm_bindgen` global we imported via
 // `importScripts`.
 self.onmessage = event => {
-    let [ module, memory, work ] = event.data;
+    let [module, memory, work] = event.data;
 
     wasm_bindgen(module, memory).catch(err => {
         console.log(err);

--- a/src/wasm32/js/web_worker.js
+++ b/src/wasm32/js/web_worker.js
@@ -21,8 +21,9 @@ self.onmessage = event => {
         // This executes closure defined by work context.
         wasm.wasm_thread_entry_point(work);
 
-        // Once done, terminate web worker
-        close();
+        if (!wasm.keep_worker_alive()) {
+            // Once done, terminate web worker
+            close();
+        }
     });
 };
-  

--- a/src/wasm32/js/web_worker_module.js
+++ b/src/wasm32/js/web_worker_module.js
@@ -21,7 +21,9 @@ self.onmessage = event => {
         // This executes closure defined by work context.
         wasm_thread_entry_point(work);
 
-        // Once done, terminate web worker
-        close();
+        if (!wasm.keep_worker_alive()) {
+            // Once done, terminate web worker
+            close();
+        }
     });
 };

--- a/src/wasm32/js/web_worker_module.js
+++ b/src/wasm32/js/web_worker_module.js
@@ -1,11 +1,11 @@
 // synchronously, using the browser, import wasm_bindgen shim JS scripts
-import init, {wasm_thread_entry_point} from "WASM_BINDGEN_SHIM_URL";
+import init, { wasm_thread_entry_point, keep_worker_alive } from "WASM_BINDGEN_SHIM_URL";
 
 // Wait for the main thread to send us the shared module/memory and work context.
 // Once we've got it, initialize it all with the `wasm_bindgen` global we imported via
 // `importScripts`.
 self.onmessage = event => {
-    let [ module, memory, work ] = event.data;
+    let [module, memory, work] = event.data;
 
     init(module, memory).catch(err => {
         console.log(err);
@@ -21,7 +21,7 @@ self.onmessage = event => {
         // This executes closure defined by work context.
         wasm_thread_entry_point(work);
 
-        if (!wasm.keep_worker_alive()) {
+        if (!keep_worker_alive()) {
             // Once done, terminate web worker
             close();
         }

--- a/src/wasm32/mod.rs
+++ b/src/wasm32/mod.rs
@@ -33,6 +33,15 @@ pub fn wasm_thread_entry_point(ptr: u32) {
     WorkerMessage::ThreadComplete.post();
 }
 
+/// Whether to keep the worker alive or not after it's execution is done
+#[wasm_bindgen]
+pub fn keep_worker_alive() -> bool {
+    #[cfg(feature = "keep_worker_alive")]
+    return true;
+    #[cfg(not(feature = "keep_worker_alive"))]
+    return false;
+}
+
 /// Used to relay spawn requests from web workers to main thread
 struct BuilderRequest {
     builder: Builder,

--- a/src/wasm32/utils.rs
+++ b/src/wasm32/utils.rs
@@ -26,6 +26,14 @@ pub fn is_web_worker_thread() -> bool {
     js_sys::eval("self").unwrap().dyn_into::<WorkerGlobalScope>().is_ok()
 }
 
+pub fn close_current_web_worker() {
+    js_sys::eval("self")
+        .unwrap()
+        .dyn_into::<DedicatedWorkerGlobalScope>()
+        .unwrap()
+        .close();
+}
+
 #[cfg(feature = "es_modules")]
 #[wasm_bindgen(module = "/src/wasm32/js/module_workers_polyfill.min.js")]
 extern "C" {

--- a/src/wasm32/utils.rs
+++ b/src/wasm32/utils.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use wasm_bindgen::prelude::*;
-use web_sys::{Blob, Url, WorkerGlobalScope};
+use web_sys::{Blob, DedicatedWorkerGlobalScope, Url, WorkerGlobalScope};
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     if let Some(window) = web_sys::window() {


### PR DESCRIPTION
While #18 is being discussed, this PR addresses one point which is only about closing the worker after the wasm entry point call.

This allows calling methods such as `request_animation_frame`, `set_interval` etc.

The responsibility to close the worker is passed to the user, with the helper function `close_current_web_worker`