### PR TITLE
Make polyfill configurable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ categories = ["concurrency", "wasm"]
 readme = "README.md"
 
 [features]
-default = ["es_modules"]
+default = ["es_modules", "module_workers_polyfill"]
+module_workers_polyfill = []
 es_modules = []
 
 [dependencies]

--- a/src/wasm32/mod.rs
+++ b/src/wasm32/mod.rs
@@ -297,6 +297,7 @@ impl Builder {
 
         #[cfg(feature = "es_modules")]
         {
+            #[cfg(feature = "module_workers_polyfill")]
             utils::load_module_workers_polyfill();
             options.type_(WorkerType::Module);
         }

--- a/src/wasm32/utils.rs
+++ b/src/wasm32/utils.rs
@@ -26,7 +26,7 @@ pub fn is_web_worker_thread() -> bool {
     js_sys::eval("self").unwrap().dyn_into::<WorkerGlobalScope>().is_ok()
 }
 
-#[cfg(feature = "es_modules")]
+#[cfg(all(feature = "es_modules", feature = "module_workers_polyfill"))]
 #[wasm_bindgen(module = "/src/wasm32/js/module_workers_polyfill.min.js")]
 extern "C" {
     pub fn load_module_workers_polyfill();


### PR DESCRIPTION
This removes one request whenever a thread is started.

It makes sense if your application already requires even more modern APIs, in my case webgpu.

Note that for this to be observable, I did need to cargo clean before the build. I'm not entirely sure why that was required.