### PR TITLE
feat: use thread id to detect main thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ readme = "README.md"
 [features]
 default = ["es_modules"]
 es_modules = []
+spawn_from_worker = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.95"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ readme = "README.md"
 [features]
 default = ["es_modules"]
 es_modules = []
-spawn_from_worker = []
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.95"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,5 +2,5 @@
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
 channel = "nightly-2024-03-16"
-components = ["rust-src", "rustfmt"]
+components = ["rust-src", "rustfmt", "rust-analyzer"]
 targets = ["wasm32-unknown-unknown"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(thread_id_value)]
 #![cfg_attr(target_arch = "wasm32", feature(stdarch_wasm_atomic_wait))]
 
 // Import reusable APIs from std

--- a/src/wasm32/mod.rs
+++ b/src/wasm32/mod.rs
@@ -13,7 +13,7 @@ use scoped::ScopeData;
 pub use scoped::{scope, Scope, ScopedJoinHandle};
 use signal::Signal;
 use utils::SpinLockMutex;
-pub use utils::{available_parallelism, get_wasm_bindgen_shim_script_path, get_worker_script, is_web_worker_thread};
+pub use utils::{available_parallelism, get_wasm_bindgen_shim_script_path, get_worker_script, is_main_thread};
 use wasm_bindgen::prelude::*;
 use web_sys::{DedicatedWorkerGlobalScope, Worker, WorkerOptions, WorkerType};
 
@@ -250,7 +250,7 @@ impl Builder {
             func: mem::transmute::<Box<dyn FnOnce() + Send + 'a>, Box<dyn FnOnce() + Send + 'static>>(main),
         };
 
-        if is_web_worker_thread() && !cfg!(feature = "spawn_from_worker") {
+        if !is_main_thread() {
             WorkerMessage::SpawnThread(BuilderRequest { builder: self, context }).post();
         } else {
             self.spawn_for_context(context);

--- a/src/wasm32/mod.rs
+++ b/src/wasm32/mod.rs
@@ -57,8 +57,7 @@ impl WorkerMessage {
     pub fn post(self) {
         let req = Box::new(self);
 
-        js_sys::eval("self")
-            .unwrap()
+        js_sys::global()
             .dyn_into::<DedicatedWorkerGlobalScope>()
             .unwrap()
             .post_message(&JsValue::from(Box::into_raw(req) as u32))
@@ -251,7 +250,7 @@ impl Builder {
             func: mem::transmute::<Box<dyn FnOnce() + Send + 'a>, Box<dyn FnOnce() + Send + 'static>>(main),
         };
 
-        if is_web_worker_thread() {
+        if is_web_worker_thread() && !cfg!(feature = "spawn_from_worker") {
             WorkerMessage::SpawnThread(BuilderRequest { builder: self, context }).post();
         } else {
             self.spawn_for_context(context);

--- a/src/wasm32/scoped.rs
+++ b/src/wasm32/scoped.rs
@@ -7,7 +7,7 @@ use std::{
     },
 };
 
-use super::{signal::Signal, utils::is_web_worker_thread, Builder, JoinInner};
+use super::{signal::Signal, utils::is_main_thread, Builder, JoinInner};
 
 /// A scope to spawn scoped threads in.
 ///
@@ -89,7 +89,7 @@ where
     F: for<'scope> FnOnce(&'scope Scope<'scope, 'env>) -> T,
 {
     // Fail early to avoid flaky panics that depend on execution time
-    if !is_web_worker_thread() {
+    if is_main_thread() {
         panic!("scope is not allowed on the main thread");
     }
 

--- a/src/wasm32/utils.rs
+++ b/src/wasm32/utils.rs
@@ -6,7 +6,7 @@ use std::{
 
 use js_sys::Reflect;
 use wasm_bindgen::prelude::*;
-use web_sys::{Blob, Url, WorkerGlobalScope};
+use web_sys::{Blob, Url};
 
 pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     if let Ok(navigator) = Reflect::get(&js_sys::global(), &"navigator".into()) {
@@ -21,8 +21,8 @@ pub fn available_parallelism() -> io::Result<NonZeroUsize> {
     ))
 }
 
-pub fn is_web_worker_thread() -> bool {
-    js_sys::global().dyn_into::<WorkerGlobalScope>().is_ok()
+pub fn is_main_thread() -> bool {
+    std::thread::current().id().as_u64().get() == 1_u64
 }
 
 /// Extracts path of the `wasm_bindgen` generated .js shim script.


### PR DESCRIPTION
This is for that, if a wasm be initialized in web worker, not in broswer main thread, a new thread worker will never be spawned.