### PR TITLE
Fix wasm-bindgen initialization function warning

### DIFF
--- a/src/wasm32/js/web_worker.js
+++ b/src/wasm32/js/web_worker.js
@@ -5,9 +5,9 @@ importScripts('WASM_BINDGEN_SHIM_URL');
 // Once we've got it, initialize it all with the `wasm_bindgen` global we imported via
 // `importScripts`.
 self.onmessage = event => {
-    let [ module, memory, work ] = event.data;
+    const [module_or_path, memory, work] = event.data;
 
-    wasm_bindgen(module, memory).catch(err => {
+    wasm_bindgen({ module_or_path, memory }).catch(err => {
         console.log(err);
 
         // Propagate to main `onerror`:
@@ -25,4 +25,3 @@ self.onmessage = event => {
         close();
     });
 };
-  

--- a/src/wasm32/js/web_worker_module.js
+++ b/src/wasm32/js/web_worker_module.js
@@ -1,13 +1,13 @@
 // synchronously, using the browser, import wasm_bindgen shim JS scripts
-import init, {wasm_thread_entry_point} from "WASM_BINDGEN_SHIM_URL";
+import init, { wasm_thread_entry_point } from "WASM_BINDGEN_SHIM_URL";
 
 // Wait for the main thread to send us the shared module/memory and work context.
 // Once we've got it, initialize it all with the `wasm_bindgen` global we imported via
 // `importScripts`.
 self.onmessage = event => {
-    let [ module, memory, work ] = event.data;
+    const [module_or_path, memory, work] = event.data;
 
-    init(module, memory).catch(err => {
+    init({ module_or_path, memory }).catch(err => {
         console.log(err);
 
         // Propagate to main `onerror`:


### PR DESCRIPTION
I've had to fork wasm_thread to add some specific features like async entrypoint and post_message. I hope to upstream these changes later, but first things first.

JS shim initialization function generated by new versions of wasm-bindgen now looks like this:

```
async function __wbg_init(module_or_path, memory) {
    ...
    if (Object.getPrototypeOf(module_or_path) === Object.prototype) {
        ({module_or_path, memory, thread_stack_size} = module_or_path)
    } else {
        console.warn('using deprecated parameters for the initialization function; pass a single object instead')
    }
    ...
```

It excepts both module and memory to be passed using one object (see diff), otherwise logs a warning.

This PR also contains some changes my IDE did without asking me, but I guess it's for good.